### PR TITLE
Add supervisor for automatic server restart

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -19,3 +19,5 @@ docs/_modules
 .coverage
 .vscode/
 **/pip-wheel-metadata
+supervisord.log
+supervisord.pid

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7-slim
 RUN apt-get update
 # libpq-dev gcc are added here to ensure psychopg2 installs correctly
-RUN apt-get install -y git python3-pip python3-dev libpq-dev gcc
+RUN apt-get install -y git python3-pip python3-dev libpq-dev gcc supervisor
 COPY requirements.txt /server/requirements.txt
 
 WORKDIR /server
@@ -10,4 +10,5 @@ RUN pip3 install -r requirements.txt
 # remove gcc when done with installing psycopg2
 RUN apt-get autoremove -y gcc
 COPY . /server
-ENTRYPOINT ["python", "run.py"]
+
+ENTRYPOINT ["supervisord", "-n", "-c", "/server/supervisord.conf"]

--- a/server/supervisord.conf
+++ b/server/supervisord.conf
@@ -1,0 +1,12 @@
+[supervisord]
+user = root
+nodaemon = true
+loglevel = DEBUG
+
+[program:private_identity_server]
+command = python3 -u /server/run.py
+autostart = true
+autorestart = true
+startretries = 35
+redirect_stderr = true
+redirect_stdout = true


### PR DESCRIPTION
This PR provides a solution for issue #4.

By introducing supervisor, the Flask app can now be restarted when it fails, instead of directly finishing the docker container. The pushed configuration tries to restart the app a total of 35 times. In its current state, supervisor delays every retry by 1 second. This means:

- a delay of 1 second for the first retry and a delay of 35 seconds on the last retry.
- a total of 10.5 min delay from first try to last try before supervisor gives up relaunching the app.
- after the last retry, supervisor gives up restarting the app. Currently, this leaves the container running without crashing (as supervisor process keeps running), but with the Flask server down indefinitely, unless manually started.

If this approach is accepted, a follow-up PR with a workaround still needs to be added to restart the app once supervisor gives up restarting it, as suggested by https://github.com/Supervisor/supervisor/issues/487#issuecomment-593623461. This is needed to keep the retry delays reasonable and on an infinite loop.

